### PR TITLE
switch to w64devkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ INPUT       = EV_Nova.dat
 OUTPUT      = EV\ Nova.exe
 LDS         = EV_Nova.lds
 IMPORTS     = 0x18F000 7670
-LDFLAGS     = --section-alignment=0x1000 --subsystem=windows --enable-stdcall-fixup
+LDFLAGS     = --section-alignment=0x1000 --subsystem=windows --enable-stdcall-fixup --disable-dynamicbase --disable-nxcompat
 NFLAGS      = -f elf -Iinc/
 CFLAGS      = -std=c99 -Iinc/ -O2 -march=i486
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ Building on *nix
 
 Building on Windows
 -------------------
- - Download winbuilds, the latest winbuilds includes a bug in ld so use `win-builds-for-patching.zip` from the `files` directory in this repo
- - Extract `win-builds-for-patching.zip` and run `win-install.bat`
+ - Download [w64devkit-mini-for-patching.zip](https://github.com/FunkyFr3sh/petool/releases/latest/download/w64devkit-mini-for-patching.zip)
+ - Extract `w64devkit-mini-for-patching.zip` to `C:\`
  - run `build.cmd`

--- a/build.cmd
+++ b/build.cmd
@@ -2,7 +2,7 @@
 REM
 REM cnc-patch environment config
 REM
-set PATH=C:\win-builds-patch-32\bin
-gmake clean
-gmake
+set PATH=C:\w64devkit\bin
+make clean
+make
 pause

--- a/build_stock.cmd
+++ b/build_stock.cmd
@@ -2,7 +2,7 @@
 REM
 REM cnc-patch environment config
 REM
-set PATH=C:\win-builds-patch-32\bin
-gmake clean
-gmake stock
+set PATH=C:\w64devkit\bin
+make clean
+make stock
 pause


### PR DESCRIPTION
Once merged you'll have to use a newer build of Mingw-w64, old win-builds will not be able to build anymore

w64devkit is recommended, but any other build should do fine too